### PR TITLE
[fix] add missing update of DraggableGridItem list

### DIFF
--- a/lib/widgets/drag_target_grid.dart
+++ b/lib/widgets/drag_target_grid.dart
@@ -52,6 +52,7 @@ class DragTargetGridState extends State<DragTargetGrid> {
 
   @override
   void didUpdateWidget(DragTargetGrid oldWidget) {
+    _list = [...widget.list];
     _orgList = [...widget.orgList];
     super.didUpdateWidget(oldWidget);
   }


### PR DESCRIPTION
In my App the DraggableGridItems are just Texts with different colors.

Changing the color in the Widget build function had no effect as the internal list was not updated.